### PR TITLE
fix: add 50ms skip in OnTimer

### DIFF
--- a/MQL4/Experts/Position Sizer/Position Sizer.mq4
+++ b/MQL4/Experts/Position Sizer/Position Sizer.mq4
@@ -993,6 +993,11 @@ void OnTrade()
 //+------------------------------------------------------------------+
 void OnTimer()
 {
+    /**
+     * Release resource 50ms to prevent freeze
+     * when change symbols or close Position Sizer
+     * */
+    if (GetTickCount() - LastRecalculationTime < 50) return; 
     if (NeedToCheckToggleScaleOffOn)
     {
         if ((double)ChartGetInteger(ChartID(), CHART_WIDTH_IN_PIXELS) != PrevChartWidth)


### PR DESCRIPTION
- prevent freeze during symbol change and panel close

Scenarios when experienced freeze
1) When used on multiple windows, close Position Sizer by modal window close button will 8 of 10 times freeze application no matter how long I wait.
2) Some times 3 out of 10 times, when just switch symbol, I experience 10secs freeze.
3) Some times 7-8 out of 10 times, when used on one window, with totally one window, close penal modal window by modal dialog button also causes un-recoverable freeze.

Environment: 
Windows 10 Home. 16GB RAM, Intel -5-8259U, 4cores, NVMe SSD, with more than plenty of CPU and RAM resource.